### PR TITLE
Fix: Improve collapsible card visibility and quiz modal state handling.

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -19,6 +19,8 @@
   --key-takeaway-bg: #e8f5e9;
   --glass-bg: rgba(255, 255, 255, 0.05);
   --button-hover-gradient: linear-gradient(90deg, #3A86FF, #9D4EDD);
+  --primary-rgb: 58, 134, 255;
+  --secondary-rgb: 157, 78, 221;
   
   /* Animation durations */
   --transition-fast: 150ms;
@@ -547,4 +549,25 @@ body {
   .callout, .case-study, .key-takeaway, .example {
     padding: 1rem;
   }
+}
+
+.background-gradient-blur-container {
+  position: relative;
+  isolation: isolate; /* Create a new stacking context */
+}
+
+.background-gradient-blur-container::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: -1; /* Behind content */
+  background-image: 
+    radial-gradient(ellipse at 20% 30%, rgba(var(--primary-rgb), 0.15), transparent 70%),
+    radial-gradient(ellipse at 80% 70%, rgba(var(--secondary-rgb), 0.15), transparent 70%);
+  filter: blur(60px); /* Adjust blur amount */
+  opacity: 0.7; /* Adjust opacity */
+  pointer-events: none; /* Ensure it doesn't interfere with interactions */
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,7 +7,7 @@ import Link from "next/link";
 
 export default function Home() {
   return (
-    <div className="flex flex-col min-h-screen">
+    <div className="flex flex-col min-h-screen background-gradient-blur-container">
       <Navigation />
 
       <main className="flex-grow container mx-auto px-4 sm:px-8 py-8 sm:py-12">
@@ -102,30 +102,30 @@ export default function Home() {
           </motion.h2>
           <div className="grid sm:grid-cols-2 md:grid-cols-3 gap-6 sm:gap-8">
             <motion.div 
-              initial={{ opacity: 0, y: 30 }}
+              initial={{ opacity: 0, y: 50 }}
               whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: true }}
-              transition={{ delay: 0.1, duration: 0.5 }}
+              viewport={{ once: true, amount: 0.3 }}
+              transition={{ delay: 0.1, duration: 0.6 }}
               className="bg-glass p-5 sm:p-6 rounded-lg shadow-sm border border-gray-100 text-white"
             >
               <div className="text-primary font-bold text-lg sm:text-xl mb-2">1. Learn Concepts</div>
               <p>Start with bite-sized lessons on tokenomics fundamentals and advanced concepts.</p>
             </motion.div>
             <motion.div 
-              initial={{ opacity: 0, y: 30 }}
+              initial={{ opacity: 0, y: 50 }}
               whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: true }}
-              transition={{ delay: 0.2, duration: 0.5 }}
+              viewport={{ once: true, amount: 0.3 }}
+              transition={{ delay: 0.2, duration: 0.6 }}
               className="bg-glass p-5 sm:p-6 rounded-lg shadow-sm border border-gray-100 text-white"
             >
               <div className="text-primary font-bold text-lg sm:text-xl mb-2">2. Experiment</div>
               <p>Use the simulator to adjust parameters and see how they affect token metrics over time.</p>
             </motion.div>
             <motion.div 
-              initial={{ opacity: 0, y: 30 }}
+              initial={{ opacity: 0, y: 50 }}
               whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: true }}
-              transition={{ delay: 0.3, duration: 0.5 }}
+              viewport={{ once: true, amount: 0.3 }}
+              transition={{ delay: 0.3, duration: 0.6 }}
               className="bg-glass p-5 sm:p-6 rounded-lg shadow-sm border border-gray-100 text-white"
             >
               <div className="text-primary font-bold text-lg sm:text-xl mb-2">3. Master</div>

--- a/src/components/animations/animations.ts
+++ b/src/components/animations/animations.ts
@@ -36,8 +36,8 @@ export const fadeInUp = {
 
 // Button hover animation
 export const buttonHover = {
-  scale: 1.03,
-  transition: { duration: 0.2 },
+  scale: 1.05,
+  transition: { type: "spring", stiffness: 300 },
 };
 
 // Link hover animation

--- a/src/components/interactive/CollapsibleCard.tsx
+++ b/src/components/interactive/CollapsibleCard.tsx
@@ -22,7 +22,7 @@ export default function CollapsibleCard({ title, content, className = "" }: Coll
       <button
         type="button"
         onClick={toggleOpen}
-        className="collapsible-card-header flex items-center justify-between w-full p-4 text-left bg-gray-50 hover:bg-gray-100 focus:outline-none"
+        className="collapsible-card-header flex items-center justify-between w-full p-4 text-left bg-gray-200 text-gray-800 hover:bg-gray-300 focus:outline-none"
         aria-expanded={isOpen}
       >
         <div className="font-medium">{title}</div>

--- a/src/components/interactive/QuizModal.tsx
+++ b/src/components/interactive/QuizModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { Confetti } from "@/components/animations";
 
@@ -26,6 +26,18 @@ export default function QuizModal({
   const [hasAnswered, setHasAnswered] = useState(false);
   const [showConfetti, setShowConfetti] = useState(false);
 
+  const resetQuizState = () => {
+    setSelectedAnswer(null);
+    setHasAnswered(false);
+    setShowConfetti(false);
+  };
+
+  useEffect(() => {
+    if (isOpen) {
+      resetQuizState();
+    }
+  }, [isOpen]);
+
   if (!isOpen) return null;
 
   const handleAnswerSelect = (answer: string) => {
@@ -43,7 +55,13 @@ export default function QuizModal({
   };
 
   const handleNextLesson = () => {
+    resetQuizState();
     router.push(nextLessonPath);
+  };
+
+  const handleClose = () => {
+    resetQuizState();
+    onClose();
   };
 
   return (
@@ -89,7 +107,7 @@ export default function QuizModal({
               </button>
             ) : (
               <button
-                onClick={onClose}
+                onClick={handleClose}
                 className="bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded"
               >
                 Review Lesson
@@ -98,7 +116,7 @@ export default function QuizModal({
           ) : (
             <>
               <button
-                onClick={onClose}
+                onClick={handleClose}
                 className="border border-gray-300 bg-white hover:bg-gray-50 text-gray-700 font-medium py-2 px-4 rounded"
               >
                 Cancel


### PR DESCRIPTION
Feat: Enhance home page UX with gradient blurs and animations.

This commit addresses several UI and UX issues:

1.  **Collapsible Card Styling:**
    - Changed the header background of the `CollapsibleCard` component from `bg-gray-50` to `bg-gray-200`.
    - Explicitly set the header text color to `text-gray-800` for better contrast.
    - Updated the hover state background to `hover:bg-gray-300`. These changes ensure the card's title is clearly readable.

2.  **Quiz Modal State Reset:**
    - Modified `QuizModal.tsx` to correctly reset `selectedAnswer`, `hasAnswered`, and `showConfetti` states.
    - State is now reset when the modal is closed (via "Cancel", "Review Lesson" buttons), when "Continue to Next Lesson" is clicked, and also via a `useEffect` hook when the modal's `isOpen` prop becomes true. This fixes a bug where the modal would show the previous question's answer state upon reopening.

3.  **Home Page UX - Gradient Blurs:**
    - Added a full-page background gradient blur effect to the home page (`src/app/page.tsx`).
    - Implemented using CSS in `src/app/globals.css` with radial gradients derived from primary and secondary theme colors, applied via a new `.background-gradient-blur-container` class. This adds a modern, subtle visual depth to the page.

4.  **Home Page UX - Animations:**
    - Updated the hover animation for Call-to-Action buttons (using `AnimatedLink`) to `scale: 1.05` with a `spring` transition for a more responsive feel. This change was made in `src/components/animations/animations.ts`.
    - Refined the scroll-triggered animations for the "How It Works" section cards on the home page (`src/app/page.tsx`) for smoother appearance:
        - `initial` state set to `{ opacity: 0, y: 50 }`.
        - `viewport` configured to trigger animation when 30% of the card is visible (`amount: 0.3`). - `transition` duration set to `0.6s`. These animation tweaks make the home page feel more dynamic and engaging.